### PR TITLE
修复图像第一列的 2 像素偏差

### DIFF
--- a/painter.py
+++ b/painter.py
@@ -49,7 +49,7 @@ def get_board():
 	with open('board.out', 'wb+') as file:
 		file.write(request.content)
 		file.close()
-	content = str(request.content).split('\\n')
+	content = request.content.decode('ascii').split('\n')
 	board = []
 	for i in range(0, 800):
 		line = []


### PR DESCRIPTION
嘿嘿嘿…… 是个很小的坑呢，尽管这个时候 pr 已经没啥用了但还是分享一下啦x

Python 3 `bytes` 类型的 `str()` 会被包上 `b'...'` 的前后缀，导致解码图像的第一列整体偏移两个像素。Python 2 则由于不分 `bytes` 和字符串，没有这个问题……

（啊我好烦人啊 QAQ